### PR TITLE
Enhance stats reporting by excluding ignored paths

### DIFF
--- a/docs/domain-specification.md
+++ b/docs/domain-specification.md
@@ -30,7 +30,7 @@ Terms below are the **only** approved names for aggregates, entities, states, ac
 |------|---------|--------------|
 | **Visita** | The analytics product (tracker + API + dashboard). | — |
 | **Domain** | A tracked website identified by `hostname` and protected by a secret **tracking token**. May be **disabled**. Optional **ignored path patterns** exclude URL paths from tracking. | `Domain`, `tb_domains` |
-| **Ignored path pattern** | Java regex matched against page URL path; views on matching paths are not recorded. | `Domain.ignoredPathPatterns`, Backoffice **Caminhos ignorados** |
+| **Ignored path pattern** | Java regex matched against page URL path; views on matching paths are not recorded and are excluded from dashboard stats. | `Domain.ignoredPathPatterns`, Backoffice **Caminhos ignorados** |
 | **Tracking token** | Secret sent by the embed script; paired with hostname on each tracking request. | `Domain.token`, header `VISITA-DOMAIN-TOKEN` |
 | **Page** | A URL path under a domain (`/` + path). Created on first visit if the domain exists. | `Page`, `tb_pages` |
 | **View** | A browsing session segment on a page: access time, optional end time, duration, referrer, user/tab ids. | `View`, `tb_views` |

--- a/src/main/java/dev/vepo/visita/dashboard/StatsRepository.java
+++ b/src/main/java/dev/vepo/visita/dashboard/StatsRepository.java
@@ -2,10 +2,13 @@ package dev.vepo.visita.dashboard;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import dev.vepo.visita.page.Page;
 import dev.vepo.visita.stats.summary.DomainViewCount;
 import dev.vepo.visita.stats.summary.PageViewCount;
 import dev.vepo.visita.stats.summary.StatsSummary;
@@ -16,6 +19,9 @@ import jakarta.persistence.EntityManager;
 @ApplicationScoped
 public class StatsRepository {
     private static final Logger logger = LoggerFactory.getLogger(StatsRepository.class);
+    private static final String EXCLUDE_IGNORED_PAGES = "v.page.id NOT IN :excludedPageIds";
+    private static final Set<Long> NO_EXCLUDED_PAGES = Set.of(-1L);
+
     private final EntityManager entityManager;
 
     @Inject
@@ -25,6 +31,7 @@ public class StatsRepository {
 
     public List<DailyStats> buildDailyViews(Selector selector, String parameter, LocalDateTime startDate, LocalDateTime endDate) {
         logger.info("Building daily stats {}={}, startDate={}, endDate={}", selector, parameter, startDate, endDate);
+        var excludedPageIds = excludedPageIdsParameter();
         return switch (selector) {
             case REFERRER -> entityManager.createQuery("""
                                                        SELECT new DailyStats(DATE(v.accessTimestamp),
@@ -36,12 +43,14 @@ public class StatsRepository {
                                                        WHERE (v.originalReferrer = :referrer OR v.referrer = :referrer) AND
                                                              v.accessTimestamp IS NOT NULL AND
                                                              v.length IS NOT NULL AND
+                                                             %s AND
                                                              (COALESCE(:startDate, NULL) IS NULL OR v.accessTimestamp >= :startDate) AND
                                                              (COALESCE(:endDate, NULL) IS NULL OR v.accessTimestamp < :endDate)
                                                        GROUP BY DATE(v.accessTimestamp)
                                                        ORDER BY DATE(v.accessTimestamp) DESC
-                                                       """, DailyStats.class)
+                                                       """.formatted(EXCLUDE_IGNORED_PAGES), DailyStats.class)
                                           .setParameter("referrer", parameter)
+                                          .setParameter("excludedPageIds", excludedPageIds)
                                           .setParameter("startDate", startDate)
                                           .setParameter("endDate", endDate)
                                           .getResultStream()
@@ -55,12 +64,14 @@ public class StatsRepository {
                                                      FROM View v
                                                      WHERE v.page.domain.hostname = :hostname AND
                                                            v.accessTimestamp IS NOT NULL AND v.length IS NOT NULL AND
+                                                           %s AND
                                                            (COALESCE(:startDate, NULL) IS NULL OR v.accessTimestamp >= :startDate) AND
                                                            (COALESCE(:endDate, NULL) IS NULL OR v.accessTimestamp < :endDate)
                                                      GROUP BY DATE(v.accessTimestamp)
                                                      ORDER BY DATE(v.accessTimestamp) DESC
-                                                     """, DailyStats.class)
+                                                     """.formatted(EXCLUDE_IGNORED_PAGES), DailyStats.class)
                                         .setParameter("hostname", parameter)
+                                        .setParameter("excludedPageIds", excludedPageIds)
                                         .setParameter("startDate", startDate)
                                         .setParameter("endDate", endDate)
                                         .getResultStream()
@@ -74,11 +85,13 @@ public class StatsRepository {
                                                    FROM View v
                                                    WHERE v.accessTimestamp IS NOT NULL AND
                                                          v.length IS NOT NULL AND
+                                                         %s AND
                                                          (COALESCE(:startDate, NULL) IS NULL OR v.accessTimestamp >= :startDate) AND
                                                          (COALESCE(:endDate, NULL) IS NULL OR v.accessTimestamp < :endDate)
                                                    GROUP BY DATE(v.accessTimestamp)
                                                    ORDER BY DATE(v.accessTimestamp) DESC
-                                                   """, DailyStats.class)
+                                                   """.formatted(EXCLUDE_IGNORED_PAGES), DailyStats.class)
+                                      .setParameter("excludedPageIds", excludedPageIds)
                                       .setParameter("startDate", startDate)
                                       .setParameter("endDate", endDate)
                                       .getResultStream()
@@ -88,6 +101,7 @@ public class StatsRepository {
     }
 
     public List<PageStats> buildPageViews(Selector selector, String parameter, LocalDateTime startDate, LocalDateTime endDate) {
+        var excludedPageIds = excludedPageIdsParameter();
         return switch (selector) {
             case REFERRER -> entityManager.createQuery("""
                                                        SELECT new PageStats(v.page,
@@ -99,12 +113,14 @@ public class StatsRepository {
                                                        WHERE v.page IS NOT NULL AND
                                                              (v.originalReferrer = :referrer OR v.referrer = :referrer) AND
                                                              v.length IS NOT NULL AND
+                                                             %s AND
                                                              (COALESCE(:startDate, NULL) IS NULL OR v.accessTimestamp >= :startDate) AND
                                                              (COALESCE(:endDate, NULL) IS NULL OR v.accessTimestamp < :endDate)
                                                        GROUP BY v.page
                                                        ORDER BY views DESC
-                                                       """, PageStats.class)
+                                                       """.formatted(EXCLUDE_IGNORED_PAGES), PageStats.class)
                                           .setParameter("referrer", parameter)
+                                          .setParameter("excludedPageIds", excludedPageIds)
                                           .setParameter("startDate", startDate)
                                           .setParameter("endDate", endDate)
                                           .getResultStream()
@@ -119,12 +135,14 @@ public class StatsRepository {
                                                      WHERE v.page IS NOT NULL AND
                                                            v.page.domain.hostname = :hostname AND
                                                            v.length IS NOT NULL AND
+                                                           %s AND
                                                            (COALESCE(:startDate, NULL) IS NULL OR v.accessTimestamp >= :startDate) AND
                                                            (COALESCE(:endDate, NULL) IS NULL OR v.accessTimestamp < :endDate)
                                                      GROUP BY v.page
                                                      ORDER BY views DESC
-                                                     """, PageStats.class)
+                                                     """.formatted(EXCLUDE_IGNORED_PAGES), PageStats.class)
                                         .setParameter("hostname", parameter)
+                                        .setParameter("excludedPageIds", excludedPageIds)
                                         .setParameter("startDate", startDate)
                                         .setParameter("endDate", endDate)
                                         .getResultStream()
@@ -138,11 +156,13 @@ public class StatsRepository {
                                                    FROM View v
                                                    WHERE v.page IS NOT NULL AND
                                                          v.length IS NOT NULL AND
+                                                         %s AND
                                                          (COALESCE(:startDate, NULL) IS NULL OR v.accessTimestamp >= :startDate) AND
                                                          (COALESCE(:endDate, NULL) IS NULL OR v.accessTimestamp < :endDate)
                                                    GROUP BY v.page
                                                    ORDER BY views DESC
-                                                   """, PageStats.class)
+                                                   """.formatted(EXCLUDE_IGNORED_PAGES), PageStats.class)
+                                      .setParameter("excludedPageIds", excludedPageIds)
                                       .setParameter("startDate", startDate)
                                       .setParameter("endDate", endDate)
                                       .getResultStream()
@@ -152,6 +172,7 @@ public class StatsRepository {
     }
 
     public List<PageStats> buildPageViewsFromDate(Selector selector, String parameter, LocalDateTime startDate) {
+        var excludedPageIds = excludedPageIdsParameter();
         return switch (selector) {
             case DOMAIN -> entityManager.createQuery("""
                                                      SELECT new PageStats(v.page,
@@ -163,13 +184,15 @@ public class StatsRepository {
                                                      WHERE v.page IS NOT NULL AND
                                                            v.page.domain.hostname = :hostname AND
                                                            v.length IS NOT NULL AND
+                                                           %s AND
                                                            v.accessTimestamp >= :start_date
                                                      GROUP BY v.page
                                                      ORDER BY views DESC
-                                                     """,
+                                                     """.formatted(EXCLUDE_IGNORED_PAGES),
                                                      PageStats.class)
                                         .setParameter("start_date", startDate)
                                         .setParameter("hostname", parameter)
+                                        .setParameter("excludedPageIds", excludedPageIds)
                                         .getResultStream()
                                         .toList();
             case REFERRER -> entityManager.createQuery("""
@@ -182,13 +205,15 @@ public class StatsRepository {
                                                        WHERE v.page IS NOT NULL AND
                                                              (v.originalReferrer = :referrer OR v.referrer = :referrer) AND
                                                              v.length IS NOT NULL AND
+                                                             %s AND
                                                              v.accessTimestamp >= :start_date
                                                        GROUP BY v.page
                                                        ORDER BY views DESC
-                                                       """,
+                                                       """.formatted(EXCLUDE_IGNORED_PAGES),
                                                        PageStats.class)
                                           .setParameter("start_date", startDate)
                                           .setParameter("referrer", parameter)
+                                          .setParameter("excludedPageIds", excludedPageIds)
                                           .getResultStream()
                                           .toList();
             case NONE -> entityManager.createQuery("""
@@ -200,11 +225,13 @@ public class StatsRepository {
                                                    FROM View v
                                                    WHERE v.page IS NOT NULL AND
                                                          v.length IS NOT NULL AND
+                                                         %s AND
                                                          v.accessTimestamp >= :start_date
                                                    GROUP BY v.page
                                                    ORDER BY views DESC
-                                                   """, PageStats.class)
+                                                   """.formatted(EXCLUDE_IGNORED_PAGES), PageStats.class)
                                       .setParameter("start_date", startDate)
+                                      .setParameter("excludedPageIds", excludedPageIds)
                                       .getResultStream()
                                       .toList();
             default -> throw new UnsupportedOperationException("Selector not implemented! selector=%s".formatted(selector));
@@ -212,6 +239,7 @@ public class StatsRepository {
     }
 
     public List<ReferrerStats> buildReferrerStats(Selector selector, String parameter, LocalDateTime startDate, LocalDateTime endDate) {
+        var excludedPageIds = excludedPageIdsParameter();
         return switch (selector) {
             case DOMAIN -> entityManager.createQuery("""
                                                      SELECT new ReferrerStats(COALESCE(v.originalReferrer, v.referrer),
@@ -223,13 +251,15 @@ public class StatsRepository {
                                                      WHERE (v.originalReferrer IS NOT NULL OR v.referrer IS NOT NULL) AND
                                                            v.page.domain.hostname = :hostname AND
                                                            v.length IS NOT NULL AND
+                                                           %s AND
                                                            (COALESCE(:startDate, NULL) IS NULL OR v.accessTimestamp >= :startDate) AND
                                                            (COALESCE(:endDate, NULL) IS NULL OR v.accessTimestamp < :endDate)
                                                      GROUP BY COALESCE(v.originalReferrer, v.referrer)
                                                      ORDER BY views DESC
-                                                     """,
+                                                     """.formatted(EXCLUDE_IGNORED_PAGES),
                                                      ReferrerStats.class)
                                         .setParameter("hostname", parameter)
+                                        .setParameter("excludedPageIds", excludedPageIds)
                                         .setParameter("startDate", startDate)
                                         .setParameter("endDate", endDate)
                                         .getResultStream()
@@ -243,13 +273,15 @@ public class StatsRepository {
                                                        FROM View v
                                                        WHERE (v.originalReferrer = :referrer OR v.referrer = :referrer) AND
                                                              v.length IS NOT NULL AND
+                                                             %s AND
                                                              (COALESCE(:startDate, NULL) IS NULL OR v.accessTimestamp >= :startDate) AND
                                                              (COALESCE(:endDate, NULL) IS NULL OR v.accessTimestamp < :endDate)
                                                        GROUP BY COALESCE(v.originalReferrer, v.referrer)
                                                        ORDER BY views DESC
-                                                       """,
+                                                       """.formatted(EXCLUDE_IGNORED_PAGES),
                                                        ReferrerStats.class)
                                           .setParameter("referrer", parameter)
+                                          .setParameter("excludedPageIds", excludedPageIds)
                                           .setParameter("startDate", startDate)
                                           .setParameter("endDate", endDate)
                                           .getResultStream()
@@ -263,12 +295,14 @@ public class StatsRepository {
                                                    FROM View v
                                                    WHERE (v.originalReferrer IS NOT NULL OR v.referrer IS NOT NULL) AND
                                                          v.length IS NOT NULL AND
+                                                         %s AND
                                                          (COALESCE(:startDate, NULL) IS NULL OR v.accessTimestamp >= :startDate) AND
                                                          (COALESCE(:endDate, NULL) IS NULL OR v.accessTimestamp < :endDate)
                                                    GROUP BY COALESCE(v.originalReferrer, v.referrer)
                                                    ORDER BY views DESC
-                                                   """,
+                                                   """.formatted(EXCLUDE_IGNORED_PAGES),
                                                    ReferrerStats.class)
+                                      .setParameter("excludedPageIds", excludedPageIds)
                                       .setParameter("startDate", startDate)
                                       .setParameter("endDate", endDate)
                                       .getResultStream()
@@ -278,6 +312,7 @@ public class StatsRepository {
     }
 
     public List<DomainStats> buildDomainStats(Selector selector, String parameter, LocalDateTime startDate, LocalDateTime endDate) {
+        var excludedPageIds = excludedPageIdsParameter();
         return switch (selector) {
             case DOMAIN -> entityManager.createQuery("""
                                                      SELECT new DomainStats(v.page.domain.hostname,
@@ -288,13 +323,15 @@ public class StatsRepository {
                                                      FROM View v
                                                      WHERE v.page.domain.hostname = :hostname AND
                                                            v.length IS NOT NULL AND
+                                                           %s AND
                                                            (COALESCE(:startDate, NULL) IS NULL OR v.accessTimestamp >= :startDate) AND
                                                            (COALESCE(:endDate, NULL) IS NULL OR v.accessTimestamp < :endDate)
                                                      GROUP BY v.page.domain.hostname
                                                      ORDER BY views DESC
-                                                     """,
+                                                     """.formatted(EXCLUDE_IGNORED_PAGES),
                                                      DomainStats.class)
                                         .setParameter("hostname", parameter)
+                                        .setParameter("excludedPageIds", excludedPageIds)
                                         .setParameter("startDate", startDate)
                                         .setParameter("endDate", endDate)
                                         .getResultStream()
@@ -308,13 +345,15 @@ public class StatsRepository {
                                                        FROM View v
                                                        WHERE (v.originalReferrer = :referrer OR v.referrer = :referrer) AND
                                                              v.length IS NOT NULL AND
+                                                             %s AND
                                                              (COALESCE(:startDate, NULL) IS NULL OR v.accessTimestamp >= :startDate) AND
                                                              (COALESCE(:endDate, NULL) IS NULL OR v.accessTimestamp < :endDate)
                                                        GROUP BY v.page.domain.hostname
                                                        ORDER BY views DESC
-                                                       """,
+                                                       """.formatted(EXCLUDE_IGNORED_PAGES),
                                                        DomainStats.class)
                                           .setParameter("referrer", parameter)
+                                          .setParameter("excludedPageIds", excludedPageIds)
                                           .setParameter("startDate", startDate)
                                           .setParameter("endDate", endDate)
                                           .getResultStream()
@@ -327,12 +366,14 @@ public class StatsRepository {
                                                        PERCENTILE_DISC(0.9) WITHIN GROUP (ORDER BY v.length) as avgDurationPerc90)
                                                    FROM View v
                                                    WHERE v.length IS NOT NULL AND
+                                                         %s AND
                                                          (COALESCE(:startDate, NULL) IS NULL OR v.accessTimestamp >= :startDate) AND
                                                          (COALESCE(:endDate, NULL) IS NULL OR v.accessTimestamp < :endDate)
                                                    GROUP BY v.page.domain.hostname
                                                    ORDER BY views DESC
-                                                   """,
+                                                   """.formatted(EXCLUDE_IGNORED_PAGES),
                                                    DomainStats.class)
+                                      .setParameter("excludedPageIds", excludedPageIds)
                                       .setParameter("startDate", startDate)
                                       .setParameter("endDate", endDate)
                                       .getResultStream()
@@ -343,95 +384,120 @@ public class StatsRepository {
 
     @SuppressWarnings("unchecked")
     public List<UniqueUsersStats> buildUniqueViews(Selector selector, String parameter, LocalDateTime startDate, LocalDateTime endDate) {
+        var excludedPageIds = excludedPageIdsParameter();
         return switch (selector) {
             case DOMAIN -> entityManager.createNativeQuery("""
                                                            WITH available_days AS (
-                                                               SELECT DATE(access_timestamp) as currentDay
-                                                               FROM tb_views
+                                                               SELECT DATE(v.access_timestamp) as currentDay
+                                                               FROM tb_views v
+                                                               LEFT JOIN tb_pages p ON v.page_id = p.id
                                                                WHERE access_timestamp IS NOT NULL AND
+                                                                     COALESCE(p.id, -1) NOT IN (:excludedPageIds) AND
                                                                      (COALESCE(:startDate, NULL) IS NULL OR access_timestamp >= :startDate) AND
                                                                      (COALESCE(:endDate, NULL) IS NULL OR access_timestamp < :endDate)
-                                                               GROUP BY DATE(access_timestamp)
+                                                               GROUP BY DATE(v.access_timestamp)
                                                            )
                                                            SELECT currentDay,
                                                                   (SELECT COUNT(DISTINCT v.user_id) FROM tb_views v
                                                                                                     LEFT JOIN tb_pages p ON v.page_id = p.id
                                                                                                     LEFT JOIN tb_domains d ON p.domain_id = d.id
                                                                                                     WHERE d.hostname = :hostname AND
+                                                                                                          COALESCE(p.id, -1) NOT IN (:excludedPageIds) AND
                                                                                                           v.access_timestamp <= currentDay + interval '1 day' AND
                                                                                                           v.access_timestamp >  currentDay) as dailyActiveUsers,
                                                                   (SELECT COUNT(DISTINCT v.user_id) FROM tb_views v
                                                                                                     LEFT JOIN tb_pages p ON v.page_id = p.id
                                                                                                     LEFT JOIN tb_domains d ON p.domain_id = d.id
                                                                                                     WHERE d.hostname = :hostname AND
+                                                                                                          COALESCE(p.id, -1) NOT IN (:excludedPageIds) AND
                                                                                                           v.access_timestamp <= currentDay + interval '1 day' AND
                                                                                                           v.access_timestamp >  currentDay - interval '1 week') as weeklyActiveUsers,
                                                                   (SELECT COUNT(DISTINCT v.user_id) FROM tb_views v
                                                                                                     LEFT JOIN tb_pages p ON v.page_id = p.id
                                                                                                     LEFT JOIN tb_domains d ON p.domain_id = d.id
                                                                                                     WHERE d.hostname = :hostname AND
+                                                                                                          COALESCE(p.id, -1) NOT IN (:excludedPageIds) AND
                                                                                                           v.access_timestamp <= currentDay + interval '1 day' AND
                                                                                                           v.access_timestamp >  currentDay - interval '1 month') as monthlyActiveUsers
                                                            FROM available_days
                                                            """,
                                                            UniqueUsersStats.class)
                                         .setParameter("hostname", parameter)
+                                        .setParameter("excludedPageIds", excludedPageIds)
                                         .setParameter("startDate", startDate)
                                         .setParameter("endDate", endDate)
                                         .getResultStream()
                                         .toList();
             case REFERRER -> entityManager.createNativeQuery("""
                                                              WITH available_days AS (
-                                                                 SELECT DATE(access_timestamp) as currentDay
-                                                                 FROM tb_views
+                                                                 SELECT DATE(v.access_timestamp) as currentDay
+                                                                 FROM tb_views v
+                                                                 LEFT JOIN tb_pages p ON v.page_id = p.id
                                                                  WHERE access_timestamp IS NOT NULL AND
+                                                                       COALESCE(p.id, -1) NOT IN (:excludedPageIds) AND
                                                                        (COALESCE(:startDate, NULL) IS NULL OR access_timestamp >= :startDate) AND
                                                                        (COALESCE(:endDate, NULL) IS NULL OR access_timestamp < :endDate)
-                                                                 GROUP BY DATE(access_timestamp)
+                                                                 GROUP BY DATE(v.access_timestamp)
                                                              )
                                                              SELECT currentDay,
-                                                                    (SELECT COUNT(DISTINCT user_id) FROM tb_views
+                                                                    (SELECT COUNT(DISTINCT user_id) FROM tb_views v
+                                                                                                    LEFT JOIN tb_pages p ON v.page_id = p.id
                                                                                                     WHERE (referrer = :referrer OR original_referrer = :referrer) AND
+                                                                                                          COALESCE(p.id, -1) NOT IN (:excludedPageIds) AND
                                                                                                           access_timestamp <= currentDay + interval '1 day' AND
                                                                                                           access_timestamp >  currentDay) as dailyActiveUsers,
-                                                                    (SELECT COUNT(DISTINCT user_id) FROM tb_views
+                                                                    (SELECT COUNT(DISTINCT user_id) FROM tb_views v
+                                                                                                    LEFT JOIN tb_pages p ON v.page_id = p.id
                                                                                                     WHERE (referrer = :referrer OR original_referrer = :referrer) AND
+                                                                                                          COALESCE(p.id, -1) NOT IN (:excludedPageIds) AND
                                                                                                           access_timestamp <= currentDay + interval '1 day' AND
                                                                                                           access_timestamp >  currentDay - interval '1 week') as weeklyActiveUsers,
-                                                                    (SELECT COUNT(DISTINCT user_id) FROM tb_views
+                                                                    (SELECT COUNT(DISTINCT user_id) FROM tb_views v
+                                                                                                    LEFT JOIN tb_pages p ON v.page_id = p.id
                                                                                                     WHERE (referrer = :referrer OR original_referrer = :referrer) AND
+                                                                                                          COALESCE(p.id, -1) NOT IN (:excludedPageIds) AND
                                                                                                           access_timestamp <= currentDay + interval '1 day' AND
                                                                                                           access_timestamp >  currentDay - interval '1 month') as monthlyActiveUsers
                                                              FROM available_days
                                                              """,
                                                              UniqueUsersStats.class)
                                           .setParameter("referrer", parameter)
+                                          .setParameter("excludedPageIds", excludedPageIds)
                                           .setParameter("startDate", startDate)
                                           .setParameter("endDate", endDate)
                                           .getResultStream()
                                           .toList();
             case NONE -> entityManager.createNativeQuery("""
                                                          WITH available_days AS (
-                                                             SELECT DATE(access_timestamp) as currentDay
-                                                             FROM tb_views
+                                                             SELECT DATE(v.access_timestamp) as currentDay
+                                                             FROM tb_views v
+                                                             LEFT JOIN tb_pages p ON v.page_id = p.id
                                                              WHERE access_timestamp IS NOT NULL AND
+                                                                   COALESCE(p.id, -1) NOT IN (:excludedPageIds) AND
                                                                    (COALESCE(:startDate, NULL) IS NULL OR access_timestamp >= :startDate) AND
                                                                    (COALESCE(:endDate, NULL) IS NULL OR access_timestamp < :endDate)
-                                                             GROUP BY DATE(access_timestamp)
+                                                             GROUP BY DATE(v.access_timestamp)
                                                          )
                                                          SELECT currentDay,
-                                                                (SELECT COUNT(DISTINCT user_id) FROM tb_views
-                                                                                                WHERE access_timestamp <= currentDay + interval '1 day' AND
+                                                                (SELECT COUNT(DISTINCT user_id) FROM tb_views v
+                                                                                                LEFT JOIN tb_pages p ON v.page_id = p.id
+                                                                                                WHERE COALESCE(p.id, -1) NOT IN (:excludedPageIds) AND
+                                                                                                      access_timestamp <= currentDay + interval '1 day' AND
                                                                                                       access_timestamp >  currentDay) as dailyActiveUsers,
-                                                                (SELECT COUNT(DISTINCT user_id) FROM tb_views
-                                                                                                WHERE access_timestamp <= currentDay + interval '1 day' AND
+                                                                (SELECT COUNT(DISTINCT user_id) FROM tb_views v
+                                                                                                LEFT JOIN tb_pages p ON v.page_id = p.id
+                                                                                                WHERE COALESCE(p.id, -1) NOT IN (:excludedPageIds) AND
+                                                                                                      access_timestamp <= currentDay + interval '1 day' AND
                                                                                                       access_timestamp >  currentDay - interval '1 week') as weeklyActiveUsers,
-                                                                (SELECT COUNT(DISTINCT user_id) FROM tb_views
-                                                                                                WHERE access_timestamp <= currentDay + interval '1 day' AND
+                                                                (SELECT COUNT(DISTINCT user_id) FROM tb_views v
+                                                                                                LEFT JOIN tb_pages p ON v.page_id = p.id
+                                                                                                WHERE COALESCE(p.id, -1) NOT IN (:excludedPageIds) AND
+                                                                                                      access_timestamp <= currentDay + interval '1 day' AND
                                                                                                       access_timestamp >  currentDay - interval '1 month') as monthlyActiveUsers
                                                          FROM available_days
                                                          """,
                                                          UniqueUsersStats.class)
+                                      .setParameter("excludedPageIds", excludedPageIds)
                                       .setParameter("startDate", startDate)
                                       .setParameter("endDate", endDate)
                                       .getResultStream()
@@ -462,5 +528,20 @@ public class StatsRepository {
         var totalViews = dailyViews.stream().mapToLong(DailyStats::views).sum();
 
         return new StatsSummary(totalViews, dailyViews.size(), pageViews.size(), topDomains, topPagesLastWeek);
+    }
+
+    private Set<Long> excludedPageIdsParameter() {
+        var ignoredPageIds = entityManager.createQuery("""
+                                                       SELECT p FROM Page p JOIN FETCH p.domain d
+                                                       WHERE d.ignoredPathPatterns IS NOT NULL AND TRIM(d.ignoredPathPatterns) <> ''
+                                                       """, Page.class)
+                                          .getResultStream()
+                                          .filter(page -> page.getDomain().ignoresPath(page.getPath()))
+                                          .map(Page::getId)
+                                          .collect(Collectors.toSet());
+        if (ignoredPageIds.isEmpty()) {
+            return NO_EXCLUDED_PAGES;
+        }
+        return ignoredPageIds;
     }
 }

--- a/src/test/java/dev/vepo/visita/dashboard/IgnoredPathStatsTest.java
+++ b/src/test/java/dev/vepo/visita/dashboard/IgnoredPathStatsTest.java
@@ -1,0 +1,77 @@
+package dev.vepo.visita.dashboard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import dev.vepo.infra.Given;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+
+@QuarkusTest
+class IgnoredPathStatsTest {
+
+    @Inject
+    private StatsRepository statsRepository;
+
+    @BeforeEach
+    void cleanup() {
+        Given.cleanDatabase();
+    }
+
+    @Test
+    void shouldExcludeIgnoredPathsFromPageStats() {
+        Given.domain()
+             .withHostname("localhost")
+             .withToken("local-dev")
+             .withIgnoredPathPatterns(List.of("/admin/.*", "/health"))
+             .persist();
+        Given.view()
+             .withPage("https://localhost/")
+             .withLength(30)
+             .persist();
+        Given.view()
+             .withPage("https://localhost/admin/users")
+             .withLength(30)
+             .persist();
+        Given.view()
+             .withPage("https://localhost/health")
+             .withLength(30)
+             .persist();
+
+        var stats = statsRepository.buildPageViews(Selector.DOMAIN, "localhost", null, null);
+
+        assertThat(stats).hasSize(1);
+        assertThat(stats.get(0).page()).isEqualTo("localhost/");
+        assertThat(stats.get(0).views()).isEqualTo(1L);
+    }
+
+    @Test
+    void shouldExcludeIgnoredPathsFromDailyStats() {
+        Given.domain()
+             .withHostname("localhost")
+             .withToken("local-dev")
+             .withIgnoredPathPatterns(List.of("/health"))
+             .persist();
+        Given.view()
+             .withPage("https://localhost/")
+             .withStart(Instant.now().minusSeconds(60))
+             .withLength(30)
+             .persist();
+        Given.view()
+             .withPage("https://localhost/health")
+             .withStart(Instant.now().minusSeconds(60))
+             .withLength(30)
+             .persist();
+
+        var stats = statsRepository.buildDailyViews(Selector.DOMAIN, "localhost", null, null);
+
+        assertThat(stats).hasSize(1);
+        assertThat(stats.get(0).views()).isEqualTo(1L);
+    }
+
+}


### PR DESCRIPTION
- Updated the `StatsRepository` to exclude views from ignored paths in daily and page statistics queries.
- Added a new test class `IgnoredPathStatsTest` to verify that ignored paths are correctly excluded from statistics calculations.
- Modified the domain specification to clarify the behavior of ignored path patterns in tracking.